### PR TITLE
doc: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Usage of misspell:
   -legal
     	Show legal information and exit
   -locale string
-    	Correct spellings using locale perferances for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'
+    	Correct spellings using locale preferences for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'
   -o string
     	output file or [stderr|stdout|] (default "stdout")
   -q	Do not emit misspelling output

--- a/cmd/misspell/main.go
+++ b/cmd/misspell/main.go
@@ -35,7 +35,7 @@ const (
 
 const (
 	// Note for gometalinter it must be "File:Line:Column: Msg"
-	//  note space beteen ": Msg"
+	//  note space between ": Msg"
 	defaultWriteTmpl = `{{ .Filename }}:{{ .Line }}:{{ .Column }}: corrected "{{ .Original }}" to "{{ .Corrected }}"`
 	defaultReadTmpl  = `{{ .Filename }}:{{ .Line }}:{{ .Column }}: "{{ .Original }}" is a misspelling of "{{ .Corrected }}"`
 	csvTmpl          = `{{ printf "%q" .Filename }},{{ .Line }},{{ .Column }},{{ .Original }},{{ .Corrected }}`
@@ -112,7 +112,7 @@ func main() {
 		outFlag     = flag.String("o", "stdout", "output file or [stderr|stdout|]")
 		format      = flag.String("f", "", "'csv', 'sqlite3' or custom Golang template for output")
 		ignores     = flag.String("i", "", "ignore the following corrections, comma separated")
-		locale      = flag.String("locale", "", "Correct spellings using locale perferances for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'")
+		locale      = flag.String("locale", "", "Correct spellings using locale preferences for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'")
 		mode        = flag.String("source", "auto", "Source mode: auto=guess, go=golang source, text=plain or markdown-like text")
 		debugFlag   = flag.Bool("debug", false, "Debug matching, very slow")
 		exitError   = flag.Bool("error", false, "Exit with 2 if misspelling found")

--- a/url.go
+++ b/url.go
@@ -10,7 +10,7 @@ import (
 // @(https?|ftp)://(-\.)?([^\s/?\.#-]+\.?)+(/[^\s]*)?$@iS.
 var reURL = regexp.MustCompile(`(?i)(https?|ftp)://(-\.)?([^\s/?.#]+\.?)+(/\S*)?`)
 
-// StripURL attemps to replace URLs with blank spaces, e.g.
+// StripURL attempts to replace URLs with blank spaces, e.g.
 //
 //	"xxx http://foo.com/ yyy -> "xxx          yyyy".
 func StripURL(s string) string {


### PR DESCRIPTION
This PR corrects typos in comments and the `locale` flag description.