### PR TITLE
feat: add pre-commit hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: misspell
+  name: misspell
+  description: Correct commonly misspelled English words... quickly
+  language: golang
+  entry: misspell
+  args:
+  - -w
+  - -error

--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ Usage of misspell:
   -w    Overwrite file with corrections (default is just to display)
 ```
 
+### Pre-commit hook
+
+To use misspell with [pre-commit](https://pre-commit.com/), add the following to your `.pre-commit-config.yaml`:
+
+
+```yaml
+- repo: https://github.com/golangci/misspell
+  rev: v0.6.0
+  hooks:
+    - id: misspell
+      # The hook will run on all files by default.
+      # To limit to some files only, use pre-commit patterns/types
+      # files: <pattern>
+      # exclude: <pattern>
+      # types: <types>
+```
+
 ## FAQ
 
 * [Automatic Corrections](#correct)


### PR DESCRIPTION
This ports client9/misspell#174, with some modifications:
- autofix by default in the pre-commit hook (with -w)
- don't limit on which files the hook is run by default (let users add limits if necessary).
- Add usage documentation

I put v0.6.0 in the docs because I suppose this would be a new minor release, but this can be changed if you only want to put it in a patch release.
