### PR TITLE
words.go - onlu as misspelling for only

### DIFF
--- a/words.go
+++ b/words.go
@@ -28019,6 +28019,7 @@ var DictMain = []string{
 	"omre", "more",
 	"onot", "note",
 	"onyl", "only",
+	"onlu", "only",
 	"owrk", "work",
 	"peom", "poem",
 	"pich", "pitch",


### PR DESCRIPTION
As u and y are next to each other in a QWERTY-keyboard, this is a typo that can happen somewhat easily.