### PR TITLE
chore: minor fixes to install-misspell.sh and typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ They all work but had problems that prevented me from using them at scale:
 
 * slow, all of the above check one misspelling at a time (i.e. linear) using regexps
 * not MIT/Apache2 licensed (or equivalent)
-* have dependencies that don't work for me (Python3, BASH, GNU sed, etc.)
+* have dependencies that don't work for me (Python3, Bash, GNU sed, etc.)
 * don't understand American vs. British English and sometimes makes unwelcome "corrections"
 
 That said, they might be perfect for you and many have more features than this project!

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ It doesn't work well for Python and Bash.
 <a name="csv"></a>
 ### How Can I Get CSV Output?
 
-Using `-f csv`, the output is standard comma-seprated values with headers in the first row.
+Using `-f csv`, the output is standard comma-separated values with headers in the first row.
 
 ```console
 $ misspell -f csv *
@@ -244,7 +244,7 @@ $ sqlite3 -init /tmp/misspell.sql :memory: 'select count(*) from misspell'
 1
 ```
 
-With some tricks you can directly pipe output to sqlite3 by using `-init /dev/stdin`:
+With some tricks you can directly pipe output to SQLite3 by using `-init /dev/stdin`:
 
 ```
 misspell -f sqlite * | sqlite3 -init /dev/stdin -column -cmd '.width 60 15' ':memory' \
@@ -307,7 +307,7 @@ They all work but had problems that prevented me from using them at scale:
 
 * slow, all of the above check one misspelling at a time (i.e. linear) using regexps
 * not MIT/Apache2 licensed (or equivalent)
-* have dependencies that don't work for me (python3, bash, linux sed, etc.)
+* have dependencies that don't work for me (python3, BASH, GNU sed, etc.)
 * don't understand American vs. British English and sometimes makes unwelcome "corrections"
 
 That said, they might be perfect for you and many have more features than this project!

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ $ sqlite3 -init /tmp/misspell.sql :memory: 'select count(*) from misspell'
 1
 ```
 
-With some tricks you can directly pipe output to SQLite3 by using `-init /dev/stdin`:
+With some tricks you can directly pipe output to `sqlite3` by using `-init /dev/stdin`:
 
 ```
 misspell -f sqlite * | sqlite3 -init /dev/stdin -column -cmd '.width 60 15' ':memory' \
@@ -307,7 +307,7 @@ They all work but had problems that prevented me from using them at scale:
 
 * slow, all of the above check one misspelling at a time (i.e. linear) using regexps
 * not MIT/Apache2 licensed (or equivalent)
-* have dependencies that don't work for me (python3, BASH, GNU sed, etc.)
+* have dependencies that don't work for me (Python3, BASH, GNU sed, etc.)
 * don't understand American vs. British English and sometimes makes unwelcome "corrections"
 
 That said, they might be perfect for you and many have more features than this project!

--- a/install-misspell.sh
+++ b/install-misspell.sh
@@ -236,6 +236,7 @@ untar() {
       ;;
   esac
 }
+
 http_download_curl() {
   local_file=$1
   source_url=$2
@@ -249,14 +250,12 @@ http_download_curl() {
       curl -sL -o "$local_file" "$source_url"
     else
       curl -sL -H "$header" -o "$local_file" "$source_url"
-
-      nf=$(cat "$local_file" | jq -r '.error // ""')
-      if  [ ! -z "$nf" ]; then
+      nf=$(jq -r '.error // ""' "$local_file")
+      if  [ -n "$nf" ]; then
         log_debug "http_download_curl received an error: $nf"
         return 1
       fi
     fi
-
     return 0
   fi
 
@@ -271,6 +270,7 @@ http_download_curl() {
   fi
   return 0
 }
+
 http_download_wget() {
   local_file=$1
   source_url=$2
@@ -357,8 +357,8 @@ EOF
 
 PROJECT_NAME="misspell"
 OWNER=golangci
-REPO="misspell"
-BINARY=misspell
+REPO=$PROJECT_NAME
+BINARY=$PROJECT_NAME
 FORMAT=tar.gz
 OS=$(uname_os)
 ARCH=$(uname_arch)


### PR DESCRIPTION
README: seprated->separated
install-misspell.sh:
- Make use of `PROJECT_NAME`
- `-n` instead of `! -z`
- `jq` can accept filename as an argument so no need to pipe from `cat`