### PR TITLE
fix: remove analyzes

### DIFF
--- a/internal/gen/sources/us.json
+++ b/internal/gen/sources/us.json
@@ -101,9 +101,6 @@
   "analyzed": [
     "analysed"
   ],
-  "analyzes": [
-    "analyses"
-  ],
   "analyzing": [
     "analysing"
   ],

--- a/words_us.go
+++ b/words_us.go
@@ -1339,7 +1339,6 @@ var DictAmerican = []string{
 	"amortise", "amortize",
 	"analogue", "analog",
 	"analysed", "analyzed",
-	"analyses", "analyzes",
 	"armoured", "armored",
 	"armourer", "armorer",
 	"artefact", "artifact",


### PR DESCRIPTION
The ambiguities of the word lead to false positives.

Fixes #29

